### PR TITLE
Prioritise exports when deconflicting

### DIFF
--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -138,77 +138,6 @@ export function create_module_declaration(id, entry, created, resolve) {
 
 	// step 2 - treeshaking
 	{
-		/**
-		 * @param {string} id
-		 * @param {string} name
-		 */
-		const reference = (id, name) => {
-			const declaration = trace(id, name);
-			if (!declaration.included) {
-				declaration.included = true;
-
-				for (const { module, name } of declaration.dependencies) {
-					reference(module, name);
-				}
-			}
-		};
-
-		for (const name of exports) {
-			const declaration = trace_export(entry, name);
-			if (declaration) reference(declaration.module, declaration.name);
-		}
-	}
-
-	// step 3 - deconflicting
-	{
-		/**
-		 * @param {string} id
-		 * @param {string} name
-		 * @param {string} alias
-		 */
-		const assign_alias = (id, name, alias) => {
-			const module = bundle.get(id);
-
-			if (module) {
-				if (module.exports.has(name)) {
-					const local = /** @type {string} */ (module.exports.get(name));
-
-					const declaration = module.declarations.get(local);
-					if (declaration) {
-						declaration.alias = alias;
-						return true;
-					}
-
-					const binding = module.imports.get(local);
-					if (binding) {
-						assign_alias(binding.id, binding.name, alias);
-						return true;
-					}
-
-					throw new Error('Something unexpected happened');
-				}
-
-				const binding = module.export_from.get(name);
-				if (binding) {
-					assign_alias(binding.id, binding.name, alias);
-					return true;
-				}
-
-				for (const reference of module.export_all) {
-					if (assign_alias(reference.id, name, alias)) {
-						return true;
-					}
-				}
-			} else {
-				const declaration =
-					external_imports[id]?.[name] ??
-					external_import_alls[id]?.[name] ??
-					external_export_from[id]?.[name];
-
-				declaration.alias = alias;
-			}
-		};
-
 		/** @type {Set<string>} */
 		const names = new Set();
 
@@ -223,45 +152,35 @@ export function create_module_declaration(id, entry, created, resolve) {
 			return name;
 		}
 
-		// fix export names initially...
+		/**
+		 * @param {import('./types').Declaration} declaration
+		 * @param {string} [name]
+		 */
+		const mark = (declaration, name) => {
+			if (!declaration.included) {
+				declaration.alias = get_name(name ?? declaration.name);
+				declaration.included = true;
+
+				console.log(declaration);
+
+				for (const { module, name } of declaration.dependencies) {
+					const dependency = trace(module, name);
+					mark(dependency);
+				}
+			}
+		};
+
 		for (const name of exports) {
-			assign_alias(entry, name, get_name(name));
-		}
-
-		// ...and imported bindings...
-		for (const module in external_imports) {
-			if (module === id) continue;
-
-			for (const name in external_imports[module]) {
-				external_imports[module][name].alias ||= get_name(name);
-			}
-		}
-
-		for (const module in external_import_alls) {
-			if (module === id) continue;
-
-			for (const name in external_import_alls[module]) {
-				external_import_alls[module][name].alias ||= get_name(name);
-			}
-		}
-
-		for (const module in external_export_from) {
-			if (module === id) continue;
-
-			for (const name in external_export_from[module]) {
-				external_export_from[module][name].alias ||= get_name(name);
-			}
-		}
-
-		// ...then deconflict everything else
-		for (const module of bundle.values()) {
-			for (const declaration of module.declarations.values()) {
-				declaration.alias ||= get_name(declaration.name);
+			const declaration = trace_export(entry, name);
+			if (declaration) {
+				mark(declaration, name);
+			} else {
+				throw new Error('Something strange happened');
 			}
 		}
 	}
 
-	// step 4 - generate code
+	// step 3 - generate code
 	{
 		content += `declare module '${id}' {`;
 

--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -161,8 +161,6 @@ export function create_module_declaration(id, entry, created, resolve) {
 				declaration.alias = get_name(name ?? declaration.name);
 				declaration.included = true;
 
-				console.log(declaration);
-
 				for (const { module, name } of declaration.dependencies) {
 					const dependency = trace(module, name);
 					mark(dependency);
@@ -329,19 +327,9 @@ export function create_module_declaration(id, entry, created, resolve) {
 						result.remove(a, b);
 					}
 
-					const params = new Set();
-					if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
-						if (node.typeParameters) {
-							for (const param of node.typeParameters) {
-								params.add(param.name.getText(module.ast));
-							}
-						}
-					}
-
 					walk(node, (node) => {
 						if (is_reference(node)) {
 							const name = node.getText(module.ast);
-							if (params.has(name)) return;
 
 							const declaration = trace(module.file, name);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -230,6 +230,15 @@ export function get_dts(file, created, resolve) {
 				module.exports.set(default_modifier ? 'default' : name, name);
 			}
 
+			const params = new Set();
+			if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
+				if (node.typeParameters) {
+					for (const param of node.typeParameters) {
+						params.add(param.name.getText(module.ast));
+					}
+				}
+			}
+
 			walk(node, (node) => {
 				// `import('./foo').Foo` -> `Foo`
 				if (
@@ -253,6 +262,8 @@ export function get_dts(file, created, resolve) {
 
 				if (is_reference(node)) {
 					const name = node.getText(module.ast);
+					if (params.has(name)) return;
+
 					if (name !== declaration.name) {
 						declaration.dependencies.push({
 							module: file,

--- a/test/samples/deconflict-priority/input/a.d.ts
+++ b/test/samples/deconflict-priority/input/a.d.ts
@@ -1,0 +1,2 @@
+export interface Foo {}
+export interface Bar {}

--- a/test/samples/deconflict-priority/input/b.d.ts
+++ b/test/samples/deconflict-priority/input/b.d.ts
@@ -1,0 +1,2 @@
+export interface Foo {}
+export interface Bar {}

--- a/test/samples/deconflict-priority/input/index.js
+++ b/test/samples/deconflict-priority/input/index.js
@@ -1,0 +1,5 @@
+/**
+ * @param {import('./a').Foo} foo
+ * @param {import('./b').Bar} bar
+ */
+export function x(foo, bar) {}

--- a/test/samples/deconflict-priority/output/index.d.ts
+++ b/test/samples/deconflict-priority/output/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'deconflict-priority' {
+	export function x(foo: Foo, bar: Bar): void;
+	interface Foo {}
+	interface Bar {}
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/deconflict-priority/output/index.d.ts.map
+++ b/test/samples/deconflict-priority/output/index.d.ts.map
@@ -1,0 +1,20 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"x",
+		"Foo",
+		"Bar"
+	],
+	"sources": [
+		"../input/index.js",
+		"../input/a.d.ts",
+		"../input/b.d.ts"
+	],
+	"sourcesContent": [
+		null,
+		null,
+		null
+	],
+	"mappings": ";iBAIgBA,CAACA;WCJAC,GAAGA;WCCHC,GAAGA"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,8 @@ for (const sample of fs.readdirSync('test/samples')) {
 			const parts = file.split('/');
 			const basename = parts.pop();
 
+			console.log({ file, basename, parts });
+
 			if (basename === 'index.js' || basename === 'index.ts' || basename === 'types.d.ts') {
 				const name = [sample, ...parts].join('/');
 				modules[name] = `${dir}/input/${file}`;

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,8 @@ for (const sample of fs.readdirSync('test/samples')) {
 			}
 		}
 
+		console.log(sample, modules);
+
 		await createBundle({
 			project: 'test/tsconfig.json',
 			modules,

--- a/test/test.js
+++ b/test/test.js
@@ -21,10 +21,8 @@ for (const sample of fs.readdirSync('test/samples')) {
 		};
 
 		for (const file of glob('**', { cwd: `${dir}/input`, filesOnly: true })) {
-			const parts = file.split('/');
+			const parts = file.split(/[\/\\]/);
 			const basename = parts.pop();
-
-			console.log({ file, basename, parts });
 
 			if (basename === 'index.js' || basename === 'index.ts' || basename === 'types.d.ts') {
 				const name = [sample, ...parts].join('/');
@@ -32,8 +30,6 @@ for (const sample of fs.readdirSync('test/samples')) {
 				compilerOptions.paths[name] = [`./samples/${sample}/input/${file}`];
 			}
 		}
-
-		console.log(sample, modules);
 
 		await createBundle({
 			project: 'test/tsconfig.json',


### PR DESCRIPTION
Simplifies things quite a bit, and prevents unnecessary `_1` suffixes