### PR TITLE
preserve comments as appropriate

### DIFF
--- a/test/samples/preserve-comments/input/index.js
+++ b/test/samples/preserve-comments/input/index.js
@@ -1,0 +1,6 @@
+/**
+ * @deprecated
+ */
+export function a() {
+	return 1;
+}

--- a/test/samples/preserve-comments/output/index.d.ts
+++ b/test/samples/preserve-comments/output/index.d.ts
@@ -1,0 +1,8 @@
+declare module 'preserve-comments' {
+	/**
+	 * @deprecated
+	 */
+	export function a(): number;
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/preserve-comments/output/index.d.ts.map
+++ b/test/samples/preserve-comments/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"a"
+	],
+	"sources": [
+		"../input/index.js"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";;;;iBAGgBA,CAACA"
+}


### PR DESCRIPTION
Keeps JSDoc comments that contain `@deprecated`, `@example` etc