### PR TITLE
make `lib` undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ export async function createBundle(options) {
 			declarationDir: undefined,
 			declarationMap: true,
 			emitDeclarationOnly: true,
+			lib: undefined,
 			moduleResolution: undefined,
 			noEmit: false,
 			noEmitOnError: false,


### PR DESCRIPTION
I have _no_ idea why this works, or how to reproduce the bug that I just saw (wherein `.d.ts` files weren't emitted to the virtual filesystem when the package's `tsconfig.json` included a `"lib"` option), just that this somehow fixes it