### PR TITLE
chore: add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2023 [these people](https://github.com/Rich-Harris/dts-buddy/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
 	"name": "dts-buddy",
 	"version": "0.1.13",
+	"description": "A tool for creating .d.ts bundles",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Rich-Harris/dts-buddy"
+	},
+	"license": "MIT",
 	"type": "module",
 	"dependencies": {
 		"@jridgewell/source-map": "^0.3.3",


### PR DESCRIPTION
license text taken from sveltekit, updated link to contibutors.

if gh doesn't pick up this as MIT maybe needs an update to repo metadata somewhere