### PR TITLE
correctly mark declarations as included

### DIFF
--- a/test/samples/export-type/input/foo.d.ts
+++ b/test/samples/export-type/input/foo.d.ts
@@ -1,0 +1,2 @@
+export type C = {};
+export declare class A<C> {}

--- a/test/samples/export-type/input/index.ts
+++ b/test/samples/export-type/input/index.ts
@@ -1,0 +1,1 @@
+export { A as B, C as D } from './foo.js';

--- a/test/samples/export-type/output/index.d.ts
+++ b/test/samples/export-type/output/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'export-type' {
+	export type D = {};
+	export class B<D> {}
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/export-type/output/index.d.ts.map
+++ b/test/samples/export-type/output/index.d.ts.map
@@ -1,14 +1,8 @@
 {
 	"version": 3,
 	"file": "index.d.ts",
-	"names": [
-		"C"
-	],
-	"sources": [
-		"../input/foo.d.ts"
-	],
-	"sourcesContent": [
-		null
-	],
-	"mappings": ";MAAYA,CAACA"
+	"names": [],
+	"sources": [],
+	"sourcesContent": [],
+	"mappings": ""
 }

--- a/test/samples/export-type/output/index.d.ts.map
+++ b/test/samples/export-type/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"C"
+	],
+	"sources": [
+		"../input/foo.d.ts"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";MAAYA,CAACA"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -47,8 +47,8 @@ for (const sample of fs.readdirSync('test/samples')) {
 
 		for (const file of actual) {
 			assert.equal(
-				fs.readFileSync(`${dir}/actual/${file}`, 'utf-8'),
-				fs.readFileSync(`${dir}/output/${file}`, 'utf-8'),
+				fs.readFileSync(`${dir}/actual/${file}`, 'utf-8').trim(),
+				fs.readFileSync(`${dir}/output/${file}`, 'utf-8').trim(),
 				file
 			);
 		}


### PR DESCRIPTION
#40 was an order-of-operations issue — by including an exported declaration that depended on _another_ declaration, we prevented that second declaration from being assigned the correct alias when we later discovered that it, too, was exported.

This fixes it.

I notice that no sourcemap information is being generated for types. Not sure why, but it's orthogonal to this issue so it can get fixed separately.