### PR TITLE
feat: typescript as peer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,32 +12,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Tests:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - node-version: 16
-            os: [ubuntu-latest]
-          - node-version: 16
-            os: windows-latest
+  Checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2.2.2
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: lint
-        if: ${{ !cancelled() }} # allows checks to run if one fails so we can put them all in the same job
         run: pnpm lint
       - name: check
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }} # allows checks to run if one fails so we can put them all in the same job
         run: pnpm check
+  Tests:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ 18 ]
+        os: [ ubuntu-latest ]
+        typescript: ['5.0','5.1','5.2']
+        include:
+          - node: 18
+            os: windows-latest
+            typescript: '5.2'
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2.2.2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm update typescript@~${{ matrix.typescript }}
       - name: test
-        if: ${{ !cancelled() }}
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -14,16 +14,19 @@
 		"globrex": "^0.1.2",
 		"kleur": "^4.1.5",
 		"locate-character": "^3.0.0",
-		"magic-string": "^0.30.3",
+		"magic-string": "^0.30.4",
 		"sade": "^1.8.1",
 		"tiny-glob": "^0.2.9",
-		"ts-api-utils": "^1.0.2",
-		"typescript": "~5.0.4"
+		"ts-api-utils": "^1.0.3"
+	},
+	"peerDependencies": {
+		"typescript": ">=5.0.4 <5.3"
 	},
 	"devDependencies": {
 		"@types/globrex": "^0.1.2",
-		"@types/node": "^20.5.6",
-		"prettier": "^3.0.2",
+		"@types/node": "^20.7.2",
+		"prettier": "^3.0.3",
+		"typescript": "~5.2.2",
 		"uvu": "^0.5.6"
 	},
 	"scripts": {
@@ -45,5 +48,5 @@
 		"types"
 	],
 	"bin": "./src/cli.js",
-	"packageManager": "pnpm@8.6.12"
+	"packageManager": "pnpm@8.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^3.0.0
     version: 3.0.0
   magic-string:
-    specifier: ^0.30.3
-    version: 0.30.3
+    specifier: ^0.30.4
+    version: 0.30.4
   sade:
     specifier: ^1.8.1
     version: 1.8.1
@@ -30,22 +30,22 @@ dependencies:
     specifier: ^0.2.9
     version: 0.2.9
   ts-api-utils:
-    specifier: ^1.0.2
-    version: 1.0.2(typescript@5.0.4)
-  typescript:
-    specifier: ~5.0.4
-    version: 5.0.4
+    specifier: ^1.0.3
+    version: 1.0.3(typescript@5.2.2)
 
 devDependencies:
   '@types/globrex':
     specifier: ^0.1.2
     version: 0.1.2
   '@types/node':
-    specifier: ^20.5.6
-    version: 20.5.6
+    specifier: ^20.7.2
+    version: 20.7.2
   prettier:
-    specifier: ^3.0.2
-    version: 3.0.2
+    specifier: ^3.0.3
+    version: 3.0.3
+  typescript:
+    specifier: ~5.2.2
+    version: 5.2.2
   uvu:
     specifier: ^0.5.6
     version: 0.5.6
@@ -93,8 +93,8 @@ packages:
     resolution: {integrity: sha512-W+8iW69LnEae5H09PxjpmI3CdJyKUTBAoDyqWx6T5ewhX5unBHYYQsGYXlXQP8l3HE/Y71vswPAvxkJC92FQhQ==}
     dev: true
 
-  /@types/node@20.5.6:
-    resolution: {integrity: sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==}
+  /@types/node@20.7.2:
+    resolution: {integrity: sha512-RcdC3hOBOauLP+r/kRt27NrByYtDjsXyAuSbR87O6xpsvi763WI+5fbSIvYJrXnt9w4RuxhV6eAXfIs7aaf/FQ==}
     dev: true
 
   /dequal@2.0.3:
@@ -123,8 +123,8 @@ packages:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
     dev: false
 
-  /magic-string@0.30.3:
-    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+  /magic-string@0.30.4:
+    resolution: {integrity: sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -134,8 +134,8 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  /prettier@3.0.2:
-    resolution: {integrity: sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==}
+  /prettier@3.0.3:
+    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -153,20 +153,19 @@ packages:
       globrex: 0.1.2
     dev: false
 
-  /ts-api-utils@1.0.2(typescript@5.0.4):
-    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
+  /ts-api-utils@1.0.3(typescript@5.2.2):
+    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.2.2
     dev: false
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
     hasBin: true
-    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}


### PR DESCRIPTION
tests fail for ts 5.1 and 5.2, i'm a bit at a loss for why exactly.

One fail is because an expected `const` is now a `let` which i think is more correct as  the original `const` got turned into a namespace and the number should be mutable.

The other one has to do with declaration tracking.

Added a test matrix to ensure we test the whole peer range, not bothering with ts 4.x anymore and stopping at released versions. With every new 5.x release we can extend the peer range after testing. The alternative would be to just use ^5 on the peer and just hope that new minors don't break stuff like 5.0 -> 5.1 appearantly did