### PR TITLE
feat: add support for typescript 5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18]
+        node: [18, 20]
         os: [ubuntu-latest]
-        typescript: ['5.0', '5.1', '5.2']
+        typescript: ['5.0', '5.1', '5.2', '5.3']
         include:
           - node: 18
             os: windows-latest
             typescript: '5.2'
+          - node: 20
+            os: windows-latest
+            typescript: '5.3'
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"ts-api-utils": "^1.0.3"
 	},
 	"peerDependencies": {
-		"typescript": ">=5.0.4 <5.3"
+		"typescript": ">=5.0.4 <5.4"
 	},
 	"devDependencies": {
 		"@types/globrex": "^0.1.2",
@@ -28,7 +28,7 @@
 		"@types/semver": "^7.5.3",
 		"prettier": "^3.0.3",
 		"semver": "^7.5.4",
-		"typescript": "~5.2.2",
+		"typescript": "~5.3.2",
 		"uvu": "^0.5.6"
 	},
 	"scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.2.9
   ts-api-utils:
     specifier: ^1.0.3
-    version: 1.0.3(typescript@5.2.2)
+    version: 1.0.3(typescript@5.3.2)
 
 devDependencies:
   '@types/globrex':
@@ -50,8 +50,8 @@ devDependencies:
     specifier: ^7.5.4
     version: 7.5.4
   typescript:
-    specifier: ~5.2.2
-    version: 5.2.2
+    specifier: ~5.3.2
+    version: 5.3.2
   uvu:
     specifier: ^0.5.6
     version: 0.5.6
@@ -180,17 +180,17 @@ packages:
       globrex: 0.1.2
     dev: false
 
-  /ts-api-utils@1.0.3(typescript@5.2.2):
+  /ts-api-utils@1.0.3(typescript@5.3.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: false
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.3.2:
+    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 


### PR DESCRIPTION
fixes #66 

the reason for keeping it capped at released "minor" versions of typescript instead of going with ^5 in peerDependencies is that typescript has a habit of including breaking changes in minor releases. We could be lenient here and allow unknown unreleased minors, but it can cause unforseen errors if a user updates typescript to a version we don't test, causing their type output to be wrong which in the worst case can be a breaking change for their users and if it went undetected could require them to scramble for fixes. 

