### PR TITLE
fix: support more JsDoc in path alias rewrite

### DIFF
--- a/test/samples/path-config/input/index.js
+++ b/test/samples/path-config/input/index.js
@@ -5,3 +5,26 @@
 export function foo(input) {
 	return input * 2;
 }
+
+/**
+ * @overload
+ * @param {import('#lib').Input} input
+ * @returns {import('#lib').Output}
+ *
+ * @overload
+ * @param {string} input
+ * @returns {import('#lib').Output}
+ *
+ * @param {string | import('#lib').Input} input
+ */
+export function overload(input) {
+	const input_num = typeof input === 'string' ? parseInt(input) : input;
+	return input_num * 2;
+}
+
+/**
+ * @typedef {Object} Foo
+ * @property {import('#lib').Input} foo
+ * @param {Foo} foo
+ */
+export function foo2(foo) {}

--- a/test/samples/path-config/output/index.d.ts
+++ b/test/samples/path-config/output/index.d.ts
@@ -1,5 +1,14 @@
 declare module 'path-config' {
 	export function foo(input: Input): Output;
+
+	export function overload(input: Input): Output;
+
+	export function overload(input: string): Output;
+
+	export function foo2(foo: Foo): void;
+	export type Foo = {
+		foo: Input;
+	};
 	type Input = number;
 	type Output = number;
 }

--- a/test/samples/path-config/output/index.d.ts.map
+++ b/test/samples/path-config/output/index.d.ts.map
@@ -3,6 +3,8 @@
 	"file": "index.d.ts",
 	"names": [
 		"foo",
+		"overload",
+		"foo2",
 		"Input",
 		"Output"
 	],
@@ -14,5 +16,5 @@
 		null,
 		null
 	],
-	"mappings": ";iBAIgBA,GAAGA;MCJPC,KAAKA;MACLC,MAAMA"
+	"mappings": ";iBAIgBA,GAAGA;;iBASfC,QAAQA;;iBAARA,QAAQA;;iBAgBIC,IAAIA;;;;MC7BRC,KAAKA;MACLC,MAAMA"
 }


### PR DESCRIPTION
Adding the support for path rewrite in `typedef`, `overload`, and `callback` tags. In the latest commit of Svelte 4, the  `SvelteComponent` class type definition is not generated because the `typedef ` tag has a different structure and it causes an undefined error. This also fixes that.