### PR TITLE
preserve type expressions in JSDoc annotations for tags other than `param` and `returns`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -75,18 +75,20 @@ export function clean_jsdoc(node, code) {
 				if (tag.comment) {
 					should_keep = true;
 
-					const typeExpression = /** @type {ts.JSDocTypeExpression | undefined} */ (
-						// @ts-ignore
-						tag.typeExpression
-					);
+					if (type === 'param' || type === 'returns') {
+						const typeExpression = /** @type {ts.JSDocTypeExpression | undefined} */ (
+							// @ts-ignore
+							tag.typeExpression
+						);
 
-					if (typeExpression) {
-						// turn `@param {string} foo description` into `@param foo description`
-						let a = typeExpression.pos;
-						let b = typeExpression.end;
+						if (typeExpression) {
+							// turn `@param {string} foo description` into `@param foo description`
+							let a = typeExpression.pos;
+							let b = typeExpression.end;
 
-						while (code.original[b] === ' ') b += 1;
-						code.remove(a, b);
+							while (code.original[b] === ' ') b += 1;
+							code.remove(a, b);
+						}
 					}
 				} else if (preserved_jsdoc_tags.has(type)) {
 					should_keep = true;

--- a/test/samples/throws/input/index.js
+++ b/test/samples/throws/input/index.js
@@ -1,0 +1,7 @@
+/**
+ * @throws {Error} nope
+ * @returns {never}
+ */
+export function nope() {
+	throw new Error('nope');
+}

--- a/test/samples/throws/output/index.d.ts
+++ b/test/samples/throws/output/index.d.ts
@@ -1,0 +1,8 @@
+declare module 'throws' {
+	/**
+	 * @throws {Error} nope
+	 * */
+	export function nope(): never;
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/throws/output/index.d.ts.map
+++ b/test/samples/throws/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"nope"
+	],
+	"sources": [
+		"../input/index.js"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";;;;iBAIgBA,IAAIA"
+}


### PR DESCRIPTION
The type expression in an annotation like `@throws {Error} blah` should be preserved. `@param` and `@returns` are different, as they get turned into TypeScript proper