### PR TITLE
fix: posixify path when resolving path aliases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export async function createBundle(options) {
 				}
 
 				if (replacement) {
-					let relative = path.relative(path.dirname(file), replacement);
+					let relative = path.relative(path.dirname(file), replacement).replaceAll('\\', '/');
 					if (relative[0] !== '.') relative = `./${relative}`;
 
 					code.overwrite(node.pos, node.end, `${match[1]}${relative}${match[1]}`);

--- a/test/samples/path-config/input/index.js
+++ b/test/samples/path-config/input/index.js
@@ -1,3 +1,5 @@
+export { foo_nested } from './nested/file.js';
+
 /**
  * @param {import('#lib').Input} input
  * @returns {import('#lib').Output}

--- a/test/samples/path-config/input/nested/file.js
+++ b/test/samples/path-config/input/nested/file.js
@@ -1,0 +1,7 @@
+/**
+ * @param {import('#lib').Input} input
+ * @returns {import('#lib').Output}
+ */
+export function foo_nested(input) {
+	return input * 2;
+}

--- a/test/samples/path-config/output 5.0 - 5.1/index.d.ts
+++ b/test/samples/path-config/output 5.0 - 5.1/index.d.ts
@@ -9,6 +9,7 @@ declare module 'path-config' {
 	};
 	type Input = number;
 	type Output = number;
+	export function foo_nested(input: Input): Output;
 }
 
 //# sourceMappingURL=index.d.ts.map

--- a/test/samples/path-config/output 5.0 - 5.1/index.d.ts.map
+++ b/test/samples/path-config/output 5.0 - 5.1/index.d.ts.map
@@ -6,15 +6,18 @@
 		"overload",
 		"foo2",
 		"Input",
-		"Output"
+		"Output",
+		"foo_nested"
 	],
 	"sources": [
 		"../input/index.js",
-		"../input/lib.d.ts"
+		"../input/lib.d.ts",
+		"../input/nested/file.js"
 	],
 	"sourcesContent": [
 		null,
+		null,
 		null
 	],
-	"mappings": ";iBAIgBA,GAAGA;iBASfC,QAAQA;iBAARA,QAAQA;;iBAgBIC,IAAIA;;;;MC7BRC,KAAKA;MACLC,MAAMA"
+	"mappings": ";iBAMgBA,GAAGA;iBASfC,QAAQA;iBAARA,QAAQA;;iBAgBIC,IAAIA;;;;MC/BRC,KAAKA;MACLC,MAAMA;iBCGFC,UAAUA"
 }

--- a/test/samples/path-config/output/index.d.ts
+++ b/test/samples/path-config/output/index.d.ts
@@ -11,6 +11,7 @@ declare module 'path-config' {
 	};
 	type Input = number;
 	type Output = number;
+	export function foo_nested(input: Input): Output;
 }
 
 //# sourceMappingURL=index.d.ts.map

--- a/test/samples/path-config/output/index.d.ts.map
+++ b/test/samples/path-config/output/index.d.ts.map
@@ -6,15 +6,18 @@
 		"overload",
 		"foo2",
 		"Input",
-		"Output"
+		"Output",
+		"foo_nested"
 	],
 	"sources": [
 		"../input/index.js",
-		"../input/lib.d.ts"
+		"../input/lib.d.ts",
+		"../input/nested/file.js"
 	],
 	"sourcesContent": [
 		null,
+		null,
 		null
 	],
-	"mappings": ";iBAIgBA,GAAGA;;iBASfC,QAAQA;;iBAARA,QAAQA;;iBAgBIC,IAAIA;;;;MC7BRC,KAAKA;MACLC,MAAMA"
+	"mappings": ";iBAMgBA,GAAGA;;iBASfC,QAAQA;;iBAARA,QAAQA;;iBAgBIC,IAAIA;;;;MC/BRC,KAAKA;MACLC,MAAMA;iBCGFC,UAAUA"
 }


### PR DESCRIPTION
Previously path resolving failed because it resulted in stuff like `import foo from '.\x` which is invalid, resulting in `any` types.
