### PR TITLE
Correctly resolve .jsx and .tsx dts

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -426,6 +426,8 @@ export function resolve_dts(from, to) {
 	if (file.endsWith('.d.ts')) return file;
 	if (file.endsWith('.ts')) return file.replace(/\.ts$/, '.d.ts');
 	if (file.endsWith('.js')) return file.replace(/\.js$/, '.d.ts');
+	if (file.endsWith('.jsx')) return file.replace(/\.jsx$/, '.d.ts');
+	if (file.endsWith('.tsx')) return file.replace(/\.tsx$/, '.d.ts');
 	return file + '.d.ts';
 }
 


### PR DESCRIPTION
Extensions for .jsx and .tsx are not replaced resulting in `filename.jsx.d.ts` which are not found.