### PR TITLE
allow path aliases to be nulled out

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,9 +218,7 @@ export async function createBundle(options) {
 			// resolve relative imports and aliases (from tsconfig.paths)
 			return specifier.startsWith('.')
 				? resolve_dts(path.dirname(file), specifier)
-				: compilerOptions.paths && specifier in compilerOptions.paths
-				? resolve_dts(cwd, compilerOptions.paths[specifier][0])
-				: null;
+				: compilerOptions.paths?.[specifier]?.[0] ?? null;
 		}
 
 		for (const id in modules) {


### PR DESCRIPTION
bit of an edge case but i've hit a case where we want to leave aliases in place when generating types (but respect the tsconfig during development, so we have some dummy types to check against)