### PR TITLE
handle namespaces

### DIFF
--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -245,6 +245,7 @@ export function create_module_declaration(id, entry, created, resolve) {
 				// remove `declare module 'foo'`
 				if (
 					ts.isModuleDeclaration(node) &&
+					!tsu.isNamespaceDeclaration(node) &&
 					node.modifiers?.some((modifier) => tsu.isDeclareKeyword(modifier))
 				) {
 					result.remove(node.pos, node.end);

--- a/src/utils.js
+++ b/src/utils.js
@@ -465,7 +465,7 @@ export function is_declaration(node) {
 		ts.isFunctionDeclaration(node) ||
 		ts.isVariableStatement(node) ||
 		ts.isEnumDeclaration(node) ||
-		!!(ts.isModuleDeclaration(node) && node.flags & ts.NodeFlags.Namespace)
+		tsu.isNamespaceDeclaration(node)
 	);
 }
 

--- a/test/samples/namespace-exports/input/index.ts
+++ b/test/samples/namespace-exports/input/index.ts
@@ -1,0 +1,3 @@
+import { type Namespace } from './namespace';
+
+export type X = Namespace.X;

--- a/test/samples/namespace-exports/input/namespace.ts
+++ b/test/samples/namespace-exports/input/namespace.ts
@@ -1,0 +1,9 @@
+export namespace Namespace {
+	export interface X {
+		x: string;
+	}
+
+	export interface Y {
+		y: string;
+	}
+}

--- a/test/samples/namespace-exports/output/index.d.ts
+++ b/test/samples/namespace-exports/output/index.d.ts
@@ -1,0 +1,13 @@
+declare module 'namespace-exports' {
+	export type X = Namespace.X;
+	namespace Namespace {
+		interface X {
+			x: string;
+		}
+		interface Y {
+			y: string;
+		}
+	}
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/namespace-exports/output/index.d.ts.map
+++ b/test/samples/namespace-exports/output/index.d.ts.map
@@ -1,0 +1,17 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"X",
+		"Namespace"
+	],
+	"sources": [
+		"../input/index.ts",
+		"../input/namespace.ts"
+	],
+	"sourcesContent": [
+		null,
+		null
+	],
+	"mappings": ";aAEYA,CAACA;WCFIC,SAASA"
+}


### PR DESCRIPTION
TypeScript adds a `declare` keyword for whatever reason, which we were using as a cue to strip it out of the bundle (i don't remember why exactly, just that it's important)