### PR TITLE
chore: bump versions in test matrix to include node 22 and ts 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [20, 22]
         os: [ubuntu-latest]
-        typescript: ['5.0', '5.1', '5.2', '5.3', '5.4']
+        typescript: ['5.0', '5.1', '5.2', '5.3', '5.4','5.5']
         include:
           - node: 18
+            os: ubuntu-latest
+            typescript: '5.0'
+          - node: 18
             os: windows-latest
-            typescript: '5.2'
-          - node: 20
+            typescript: '5.0'
+          - node: 22
             os: windows-latest
-            typescript: '5.3'
+            typescript: '5.5'
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         node: [20, 22]
         os: [ubuntu-latest]
-        typescript: ['5.0', '5.1', '5.2', '5.3', '5.4','5.5']
+        typescript: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
         include:
           - node: 18
             os: ubuntu-latest

--- a/test/samples/basic/output 5.5/index.d.ts
+++ b/test/samples/basic/output 5.5/index.d.ts
@@ -1,0 +1,28 @@
+declare module 'basic' {
+	/** A vector with two components */
+	interface Vector2 {
+		/** The x component */
+		x: number;
+		/** The y component */
+		y: number;
+	}
+	/**
+	 * Add two vectors
+	 * @param a the first vector
+	 * @param b the second vector
+	 * */
+	function add(a: Vector2, b: Vector2): Vector2;
+
+	export { Vector2, add };
+}
+
+declare module 'basic/subpackage' {
+	/**
+	 * Multiply two vectors
+	 * */
+	function multiply(a: import("basic").Vector2, b: import("basic").Vector2): import("basic").Vector2;
+
+	export { multiply };
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/basic/output 5.5/index.d.ts.map
+++ b/test/samples/basic/output 5.5/index.d.ts.map
@@ -1,0 +1,20 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"Vector2",
+		"add",
+		"multiply"
+	],
+	"sources": [
+		"../input/vectors.d.ts",
+		"../input/index.js",
+		"../input/subpackage/multiply.js"
+	],
+	"sourcesContent": [
+		null,
+		null,
+		null
+	],
+	"mappings": ";;WACiBA,OAAOA;;;;;;;;;;;UCKRC,GAAGA;;;;;;;;;UCAHC,QAAQA"
+}


### PR DESCRIPTION
added node 22 and ts 5.5

changed the extra includes to ensure we test with oldest and newest versions on both linux and windows