### PR TITLE
feat: support stripping internal types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dts-buddy changelog
 
+## 0.5.2
+
+- Support stripping internal types using `@internal` JSDoc tags ([#87](https://github.com/Rich-Harris/dts-buddy/pull/87))
+
 ## 0.5.1
 
 - Use more TypeScript-friendly way of preventing unintended exports ([#85](https://github.com/Rich-Harris/dts-buddy/pull/85))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dts-buddy",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "A tool for creating .d.ts bundles",
 	"repository": {
 		"type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,8 @@ export async function createBundle(options) {
 				id,
 				modules[id],
 				created,
-				resolve
+				resolve,
+				compilerOptions
 			);
 
 			types += content;

--- a/test/samples/strip-internal/input/index.ts
+++ b/test/samples/strip-internal/input/index.ts
@@ -1,0 +1,6 @@
+export { Foo } from './others';
+
+/** @internal TS itself will take care of stripping this */
+export interface TSdddd {
+	foo: boolean;
+}

--- a/test/samples/strip-internal/input/internal.d.ts
+++ b/test/samples/strip-internal/input/internal.d.ts
@@ -1,0 +1,1 @@
+export type Internal = { foo: boolean };

--- a/test/samples/strip-internal/input/others.d.ts
+++ b/test/samples/strip-internal/input/others.d.ts
@@ -1,0 +1,7 @@
+import { Internal } from './internal';
+
+export interface Foo {
+	bar: string;
+	/** @internal */
+	baz: Internal;
+}

--- a/test/samples/strip-internal/options.json
+++ b/test/samples/strip-internal/options.json
@@ -1,0 +1,3 @@
+{
+	"stripInternal": true
+}

--- a/test/samples/strip-internal/output/index.d.ts
+++ b/test/samples/strip-internal/output/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'strip-internal' {
+	export interface Foo {
+		bar: string;
+	}
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/strip-internal/output/index.d.ts.map
+++ b/test/samples/strip-internal/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"Foo"
+	],
+	"sources": [
+		"../input/others.d.ts"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";kBAEiBA,GAAGA"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,10 @@ for (const sample of fs.readdirSync('test/samples')) {
 
 		const compilerOptions = {
 			/** @type {Record<string, string[]>} */
-			paths: {}
+			paths: {},
+			...(fs.existsSync(`${dir}/options.json`)
+				? JSON.parse(fs.readFileSync(`${dir}/options.json`, 'utf-8'))
+				: {})
 		};
 
 		for (const file of glob('**', { cwd: `${dir}/input`, filesOnly: true })) {


### PR DESCRIPTION
... using `@internal` JSDoc tags, if the `stripInternal` tsconfig compiler option is enabled. This means types annotated with `@internal` will be stripped both from .js/ts files going through the TS program aswell as d.ts files going through our logic

part of https://github.com/sveltejs/svelte/issues/12292

fixes #63 