### PR TITLE
fix: better detection of references, handle namespace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # dts-buddy changelog
 
+## 0.5.3
+
+- Support `import * as X` imports ([#89](https://github.com/Rich-Harris/dts-buddy/pull/89))
+- Fix deduplication logic to rename exports in fewer cases ([#89](https://github.com/Rich-Harris/dts-buddy/pull/89))
+- Recognize import dependencies within namespaces ([#89](https://github.com/Rich-Harris/dts-buddy/pull/89))
+
 ## 0.5.2
 
 - Support stripping internal types using `@internal` JSDoc tags ([#87](https://github.com/Rich-Harris/dts-buddy/pull/87))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dts-buddy",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"description": "A tool for creating .d.ts bundles",
 	"repository": {
 		"type": "git",

--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -239,6 +239,24 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 			const index = module.dts.indexOf('//# sourceMappingURL=');
 			if (index !== -1) result.remove(index, module.dts.length);
 
+			if (module.import_all.size > 0) {
+				// remove the leading `Foo.` from references to `import * as Foo` namespace imports
+				walk(module.ast, (node) => {
+					if (is_reference(node) && ts.isQualifiedName(node.parent)) {
+						const binding = module.import_all.get(node.getText(module.ast));
+						if (binding) {
+							result.remove(node.pos, result.original.indexOf('.', node.end) + 1);
+							const declaration = bundle
+								.get(binding.id)
+								?.declarations.get(node.parent.right.getText(module.ast));
+							if (declaration?.alias) {
+								result.overwrite(node.parent.right.pos, node.parent.right.end, declaration.alias);
+							}
+						}
+					}
+				});
+			}
+
 			ts.forEachChild(module.ast, (node) => {
 				if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
 					result.remove(node.pos, node.end);
@@ -370,7 +388,6 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 						if (is_reference(node, true)) {
 							const name = node.getText(module.ast);
 
-							// TODO we shouldn't be in here for non-top level ts.QualifiedName nodes
 							const declaration = trace(module.file, name);
 
 							if (

--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -366,9 +366,11 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 							return false;
 						}
 
-						if (is_reference(node)) {
+						// We need to include the declarations because if references to them have changed, we need to update the declarations, too
+						if (is_reference(node, true)) {
 							const name = node.getText(module.ast);
 
+							// TODO we shouldn't be in here for non-top level ts.QualifiedName nodes
 							const declaration = trace(module.file, name);
 
 							if (

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,7 +15,8 @@ interface Declaration {
 	external: boolean;
 	included: boolean;
 	dependencies: Reference[];
-	/** The name we'd like to use to refer to this binding.
+	/**
+	 * The name we'd like to use to refer to this binding.
 	 * Only applies to default imports from external modules
 	 */
 	preferred_alias: string;

--- a/src/utils.js
+++ b/src/utils.js
@@ -550,12 +550,6 @@ export function is_reference(node, include_declarations = false) {
 
 	if (node.parent) {
 		if (is_declaration(node.parent)) {
-			// TODO is this even necessary? The node can't be the child of a declaration because it's the child of the variable statement already
-			// if (include_declarations && ts.isVariableStatement(node.parent)) {
-			// return node.parent.declarationList.declarations.some((declaration) => {
-			// 	return declaration.name === node;
-			// });
-			// }
 			if (ts.isVariableStatement(node.parent)) {
 				return false;
 			}
@@ -576,6 +570,11 @@ export function is_reference(node, include_declarations = false) {
 		if (ts.isBreakOrContinueStatement(node.parent)) return false;
 		if (ts.isEnumMember(node.parent)) return false;
 		if (ts.isModuleDeclaration(node.parent)) return false;
+
+		// Only X in X.Y.Z is a reference we care about
+		if (ts.isQualifiedName(node.parent)) {
+			return node.parent.left === node && ts.isIdentifier(node.parent.right);
+		}
 
 		// `const = { x: 1 }` inexplicably becomes `namespace a { let x: number; }`
 		if (ts.isVariableDeclaration(node.parent)) {

--- a/test/samples/import-all/input/index.ts
+++ b/test/samples/import-all/input/index.ts
@@ -1,0 +1,5 @@
+import * as X from './namespace';
+import * as Types from './type';
+
+export type Y = X.Namespace.X;
+export type Z = Types.Z;

--- a/test/samples/import-all/input/namespace.ts
+++ b/test/samples/import-all/input/namespace.ts
@@ -1,0 +1,5 @@
+export namespace Namespace {
+	export interface X {
+		error(): string;
+	}
+}

--- a/test/samples/import-all/input/type.ts
+++ b/test/samples/import-all/input/type.ts
@@ -1,0 +1,1 @@
+export type Z = true;

--- a/test/samples/import-all/output/index.d.ts
+++ b/test/samples/import-all/output/index.d.ts
@@ -1,0 +1,14 @@
+declare module 'import-all' {
+	export type Y =Namespace.X;
+	export type Z =Z_1;
+	namespace Namespace {
+		interface X {
+			error(): string;
+		}
+	}
+	type Z_1 = true;
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/import-all/output/index.d.ts.map
+++ b/test/samples/import-all/output/index.d.ts.map
@@ -1,0 +1,20 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"Y",
+		"Z",
+		"Namespace"
+	],
+	"sources": [
+		"../input/index.ts",
+		"../input/type.ts",
+		"../input/namespace.ts"
+	],
+	"sourcesContent": [
+		null,
+		null,
+		null
+	],
+	"mappings": ";aAGYA,CAACA;aCHDC,CAACA;WCAIC,SAASA"
+}

--- a/test/samples/namespace-exports/input/dependency.ts
+++ b/test/samples/namespace-exports/input/dependency.ts
@@ -1,0 +1,3 @@
+export interface Dependency {
+	name: string;
+}

--- a/test/samples/namespace-exports/input/index.ts
+++ b/test/samples/namespace-exports/input/index.ts
@@ -1,3 +1,4 @@
-import { type Namespace } from './namespace';
+import { type Namespace, type NamespaceWithDeps } from './namespace';
 
 export type X = Namespace.X;
+export { NamespaceWithDeps };

--- a/test/samples/namespace-exports/input/namespace.ts
+++ b/test/samples/namespace-exports/input/namespace.ts
@@ -1,3 +1,5 @@
+import { Dependency } from './dependency';
+
 export namespace Namespace {
 	export interface X {
 		x: string;
@@ -5,5 +7,11 @@ export namespace Namespace {
 
 	export interface Y {
 		y: string;
+	}
+}
+
+export namespace NamespaceWithDeps {
+	export interface Z {
+		z: Dependency;
 	}
 }

--- a/test/samples/namespace-exports/output/index.d.ts
+++ b/test/samples/namespace-exports/output/index.d.ts
@@ -8,6 +8,14 @@ declare module 'namespace-exports' {
 			y: string;
 		}
 	}
+	export namespace NamespaceWithDeps {
+		interface Z {
+			z: Dependency;
+		}
+	}
+	interface Dependency {
+		name: string;
+	}
 
 	export {};
 }

--- a/test/samples/namespace-exports/output/index.d.ts.map
+++ b/test/samples/namespace-exports/output/index.d.ts.map
@@ -3,15 +3,19 @@
 	"file": "index.d.ts",
 	"names": [
 		"X",
-		"Namespace"
+		"Namespace",
+		"NamespaceWithDeps",
+		"Dependency"
 	],
 	"sources": [
 		"../input/index.ts",
-		"../input/namespace.ts"
+		"../input/namespace.ts",
+		"../input/dependency.ts"
 	],
 	"sourcesContent": [
 		null,
+		null,
 		null
 	],
-	"mappings": ";aAEYA,CAACA;WCFIC,SAASA"
+	"mappings": ";aAEYA,CAACA;WCAIC,SAASA;;;;;;;;kBAUTC,iBAAiBA;;;;;WCZjBC,UAAUA"
 }

--- a/test/samples/no-renames/input/index.ts
+++ b/test/samples/no-renames/input/index.ts
@@ -1,0 +1,4 @@
+export { Y } from './type';
+export { Namespace } from './namespace';
+export type X = true;
+export function error(): void {}

--- a/test/samples/no-renames/input/namespace.ts
+++ b/test/samples/no-renames/input/namespace.ts
@@ -1,0 +1,5 @@
+export namespace Namespace {
+	export interface X {
+		error(): string;
+	}
+}

--- a/test/samples/no-renames/input/type.ts
+++ b/test/samples/no-renames/input/type.ts
@@ -1,0 +1,3 @@
+import { Namespace } from './namespace';
+
+export type Y = Namespace.X;

--- a/test/samples/no-renames/output/index.d.ts
+++ b/test/samples/no-renames/output/index.d.ts
@@ -1,0 +1,14 @@
+declare module 'no-renames' {
+	export type X = true;
+	export function error(): void;
+	export type Y = Namespace.X;
+	export namespace Namespace {
+		interface X {
+			error(): string;
+		}
+	}
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/no-renames/output/index.d.ts.map
+++ b/test/samples/no-renames/output/index.d.ts.map
@@ -1,0 +1,21 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"X",
+		"error",
+		"Y",
+		"Namespace"
+	],
+	"sources": [
+		"../input/index.ts",
+		"../input/type.ts",
+		"../input/namespace.ts"
+	],
+	"sourcesContent": [
+		null,
+		null,
+		null
+	],
+	"mappings": ";aAEYA,CAACA;iBACGC,KAAKA;aCDTC,CAACA;kBCFIC,SAASA"
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,5 +12,6 @@
 		"paths": {
 			"#lib": ["./samples/path-config/input/lib.d.ts"]
 		}
-	}
+	},
+	"exclude": ["**/actual/"]
 }


### PR DESCRIPTION
- fixes #86: tweak the "is this a reference logic" to not care about method signatures, and not care about the sub parts of qualified names (i.e. we only care about X in a `X.Y.Z` type reference, because we don't traverse into namespaces, and this can only be a namespace reference)
- fixes #88: add the dependencies of namespaces to the namespace declaration, or else treeshaking would wrongfully remove imports that are only dependencies of the declarations _inside_ the namespace
- also fixes `import * as X` namespace imports, they were not handled correctly before (a bit unrelated to this PR, but I came across it while investigating the whole namespace thing)

