### PR TITLE
feat: support `export { ... as default } from ...`

### DIFF
--- a/.changeset/soft-ties-agree.md
+++ b/.changeset/soft-ties-agree.md
@@ -1,5 +1,5 @@
 ---
-"dts-buddy": patch
+'dts-buddy': patch
 ---
 
 feat: support `export { ... as default} from ...`

--- a/.changeset/soft-ties-agree.md
+++ b/.changeset/soft-ties-agree.md
@@ -1,0 +1,5 @@
+---
+"dts-buddy": patch
+---
+
+feat: support `export { ... as default} from ...`

--- a/.changeset/soft-ties-agree.md
+++ b/.changeset/soft-ties-agree.md
@@ -2,4 +2,4 @@
 'dts-buddy': patch
 ---
 
-feat: support `export { ... as default} from ...`
+feat: support `export { ... as default } from ...`

--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -303,13 +303,13 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 						// foo.js:   export function foo() {}
 						// index.js  export { foo as default } from './foo.js'
 
-						let createMapping = false; // Flag to register a mapping
+						let create_mapping = false; // Flag to register a mapping if we updated the code
 
 						const default_modifier = node.modifiers?.find((node) => tsu.isDefaultKeyword(node));
 						if (!default_modifier && export_modifier) {
 							// Insert `default` after `export` if `export` is there
 							result.appendRight(export_modifier.end, ' default');
-							createMapping = true;
+							create_mapping = true;
 						} else if (!default_modifier && declare_modifier && ts.isFunctionDeclaration(node)) {
 							// Replace `declare function` with `export default function` if neither `export` nor
 							// `default` are there
@@ -319,10 +319,10 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 								'export default'
 							);
 							declare_modifier = undefined;
-							createMapping = true;
+							create_mapping = true;
 						}
 
-						if (identifier && createMapping) {
+						if (identifier && create_mapping) {
 							const pos = identifier.getStart(module.ast);
 							const loc = module.locator(pos);
 							if (loc) {

--- a/test/samples/export-as-default/input/add.js
+++ b/test/samples/export-as-default/input/add.js
@@ -1,0 +1,9 @@
+/**
+ * Add two numbers
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+export function add(a, b) {
+	return a + b;
+}

--- a/test/samples/export-as-default/input/types.d.ts
+++ b/test/samples/export-as-default/input/types.d.ts
@@ -1,0 +1,1 @@
+export { add as default } from './add.js';

--- a/test/samples/export-as-default/output/index.d.ts
+++ b/test/samples/export-as-default/output/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'export-as-default' {
+	/**
+	 * Add two numbers
+	 * */
+	export default function add(a: number, b: number): number;
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/export-as-default/output/index.d.ts.map
+++ b/test/samples/export-as-default/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"add"
+	],
+	"sources": [
+		"../input/add.d.ts"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";;;;yBAMgBA,GAAGA"
+}

--- a/test/samples/export-declare-as-default/input/add.d.ts
+++ b/test/samples/export-declare-as-default/input/add.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Add two numbers
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+declare function add(a: number, b: number): number;
+
+export { add };

--- a/test/samples/export-declare-as-default/input/types.d.ts
+++ b/test/samples/export-declare-as-default/input/types.d.ts
@@ -1,0 +1,1 @@
+export { add as default } from './add.js';

--- a/test/samples/export-declare-as-default/output/index.d.ts
+++ b/test/samples/export-declare-as-default/output/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'export-declare-as-default' {
+	/**
+	 * Add two numbers
+	 * */
+	export default function add(a: number, b: number): number;
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/export-declare-as-default/output/index.d.ts.map
+++ b/test/samples/export-declare-as-default/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"add"
+	],
+	"sources": [
+		"../input/add.d.ts"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";;;;yBAMiBA,GAAGA"
+}


### PR DESCRIPTION
Hey!

Small Sunday evening PR to add a missing feature:

```js
// add.js
export function add () {}

// index.js
export { add as default } from './add.js'
```

is now properly bundled:

```js
export default function add () {}
export {}
```

I'm not sure I did everything right, but all the tests are passing, it must not be that bad

Hope you have time to review this soon :)