### PR TITLE
fix: don't treat accessors as references

### DIFF
--- a/.changeset/violet-deer-scream.md
+++ b/.changeset/violet-deer-scream.md
@@ -1,0 +1,5 @@
+---
+'dts-buddy': patch
+---
+
+fix: don't treat accessors as references

--- a/src/utils.js
+++ b/src/utils.js
@@ -569,6 +569,8 @@ export function is_reference(node, include_declarations = false) {
 
 		if (ts.isImportTypeNode(node.parent)) return false;
 		if (ts.isPropertySignature(node.parent)) return false;
+		if (ts.isGetAccessor(node.parent)) return false;
+		if (ts.isSetAccessor(node.parent)) return false;
 		if (ts.isParameter(node.parent)) return false;
 		if (ts.isMethodDeclaration(node.parent)) return false;
 		if (ts.isLabeledStatement(node.parent)) return false;

--- a/test/samples/no-renames/input/function.ts
+++ b/test/samples/no-renames/input/function.ts
@@ -1,0 +1,1 @@
+export function bar() {}

--- a/test/samples/no-renames/input/index.ts
+++ b/test/samples/no-renames/input/index.ts
@@ -2,3 +2,9 @@ export { Y } from './type';
 export { Namespace } from './namespace';
 export type X = true;
 export function error(): void {}
+
+export interface Foo {
+	get bar(): number;
+	set bar(x: number);
+}
+export * from './function';

--- a/test/samples/no-renames/output/index.d.ts
+++ b/test/samples/no-renames/output/index.d.ts
@@ -1,12 +1,17 @@
 declare module 'no-renames' {
 	export type X = true;
 	export function error(): void;
+	export interface Foo {
+		get bar(): number;
+		set bar(x: number);
+	}
 	export type Y = Namespace.X;
 	export namespace Namespace {
 		interface X {
 			error(): string;
 		}
 	}
+	export function bar(): void;
 
 	export {};
 }

--- a/test/samples/no-renames/output/index.d.ts.map
+++ b/test/samples/no-renames/output/index.d.ts.map
@@ -4,18 +4,22 @@
 	"names": [
 		"X",
 		"error",
+		"Foo",
 		"Y",
-		"Namespace"
+		"Namespace",
+		"bar"
 	],
 	"sources": [
 		"../input/index.ts",
 		"../input/type.ts",
-		"../input/namespace.ts"
+		"../input/namespace.ts",
+		"../input/function.ts"
 	],
 	"sourcesContent": [
 		null,
 		null,
+		null,
 		null
 	],
-	"mappings": ";aAEYA,CAACA;iBACGC,KAAKA;aCDTC,CAACA;kBCFIC,SAASA"
+	"mappings": ";aAEYA,CAACA;iBACGC,KAAKA;kBAEJC,GAAGA;;;;aCHRC,CAACA;kBCFIC,SAASA;;;;;iBCAVC,GAAGA"
 }


### PR DESCRIPTION
get/set on interfaces etc were treated as references, leading to false-positive name deduplications