### PR TITLE
fix: don't remove namespaced imports if they are external

### DIFF
--- a/.changeset/ripe-apes-sleep.md
+++ b/.changeset/ripe-apes-sleep.md
@@ -1,0 +1,5 @@
+---
+'dts-buddy': patch
+---
+
+fix: don't remove namespaced imports if they are external

--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -243,10 +243,11 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 
 			if (module.import_all.size > 0) {
 				// remove the leading `Foo.` from references to `import * as Foo` namespace imports
+				// but only for internal imports, not external ones
 				walk(module.ast, (node) => {
 					if (is_reference(node) && ts.isQualifiedName(node.parent)) {
 						const binding = module.import_all.get(node.getText(module.ast));
-						if (binding) {
+						if (binding && !binding.external) {
 							result.remove(node.pos, result.original.indexOf('.', node.end) + 1);
 							const declaration = bundle
 								.get(binding.id)

--- a/test/samples/import-external-all-as/input/external.d.ts
+++ b/test/samples/import-external-all-as/input/external.d.ts
@@ -1,0 +1,9 @@
+declare module 'all-as-external' {
+	export type BaseType<T> = {
+		type: T;
+	};
+
+	export function string(): BaseType<string>;
+
+	export type Infer<T extends BaseType<any>> = T extends BaseType<infer U> ? U : never;
+}

--- a/test/samples/import-external-all-as/input/index.js
+++ b/test/samples/import-external-all-as/input/index.js
@@ -1,0 +1,7 @@
+import * as v from 'all-as-external';
+
+export const Schema = v.string();
+
+/**
+ * @typedef {v.Infer<typeof Schema>} Test
+ */

--- a/test/samples/import-external-all-as/output/index.d.ts
+++ b/test/samples/import-external-all-as/output/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'import-external-all-as' {
+	import * as v from 'all-as-external';
+	export const Schema: v.BaseType<string>;
+	export type Test = v.Infer<typeof Schema>;
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/import-external-all-as/output/index.d.ts.map
+++ b/test/samples/import-external-all-as/output/index.d.ts.map
@@ -1,0 +1,15 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"Schema",
+		"Test"
+	],
+	"sources": [
+		"../input/index.js"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";;cAEaA,MAAMA;aAGkBC,IAAIA"
+}


### PR DESCRIPTION
I've added a declaration file for `all-as-external` in the test because otherwise the fix was not really visible (i didn't use `external` or it would've effected the other tests)