### PR TITLE
feat: TypeScript 5.9 support

### DIFF
--- a/.changeset/big-fans-relax.md
+++ b/.changeset/big-fans-relax.md
@@ -1,0 +1,5 @@
+---
+'dts-buddy': minor
+---
+
+feat: TypeScript 5.9 support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22]
+        node: [20, 22, 24]
         os: [ubuntu-latest]
-        typescript: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8']
+        typescript: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9']
         include:
           - node: 18
             os: ubuntu-latest
@@ -45,9 +45,9 @@ jobs:
           - node: 18
             os: windows-latest
             typescript: '5.0'
-          - node: 22
+          - node: 24
             os: windows-latest
-            typescript: '5.7'
+            typescript: '5.9'
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"ts-api-utils": "^1.0.3"
 	},
 	"peerDependencies": {
-		"typescript": ">=5.0.4 <5.9"
+		"typescript": ">=5.0.4 <6"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.28.1",
@@ -27,7 +27,7 @@
 		"@types/semver": "^7.5.3",
 		"prettier": "^3.0.3",
 		"semver": "^7.5.4",
-		"typescript": "~5.8.3",
+		"typescript": "~5.9.3",
 		"uvu": "^0.5.6"
 	},
 	"scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 0.2.10
       ts-api-utils:
         specifier: ^1.0.3
-        version: 1.0.3(typescript@5.8.3)
+        version: 1.0.3(typescript@5.9.3)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.28.1
@@ -49,8 +49,8 @@ importers:
         specifier: ^7.5.4
         version: 7.5.4
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.3
+        version: 5.9.3
       uvu:
         specifier: ^0.5.6
         version: 0.5.6
@@ -500,8 +500,8 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1003,11 +1003,11 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@1.0.3(typescript@5.8.3):
+  ts-api-utils@1.0.3(typescript@5.9.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
-  typescript@5.8.3: {}
+  typescript@5.9.3: {}
 
   undici-types@5.25.3: {}
 


### PR DESCRIPTION
closes https://github.com/sveltejs/dts-buddy/issues/113

there's also a `6.0.0-beta` build available, but that would require larger changes from someone a bit more familiar with this project