### PR TITLE
chore: upgrade `@types/node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.28.1",
-		"@types/node": "^20.7.2",
+		"@types/node": "^24.1.0",
 		"@types/semver": "^7.5.3",
 		"prettier": "^3.0.3",
 		"semver": "^7.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^2.28.1
         version: 2.28.1
       '@types/node':
-        specifier: ^20.7.2
-        version: 20.8.6
+        specifier: ^24.1.0
+        version: 24.10.13
       '@types/semver':
         specifier: ^7.5.3
         version: 7.5.3
@@ -158,8 +158,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@20.8.6':
-    resolution: {integrity: sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==}
+  '@types/node@24.10.13':
+    resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
   '@types/semver@7.5.3':
     resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
@@ -505,8 +505,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@5.25.3:
-    resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -725,9 +725,9 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@20.8.6':
+  '@types/node@24.10.13':
     dependencies:
-      undici-types: 5.25.3
+      undici-types: 7.16.0
 
   '@types/semver@7.5.3': {}
 
@@ -1009,7 +1009,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@5.25.3: {}
+  undici-types@7.16.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
This should fix the publish failure. `pnpm prepublish` fails without this change