### PR TITLE
fix: skip traversing directories that have been excluded

### DIFF
--- a/.changeset/dull-shoes-occur.md
+++ b/.changeset/dull-shoes-occur.md
@@ -1,0 +1,5 @@
+---
+'dts-buddy': patch
+---
+
+fix: avoid traversing directories that have been excluded

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,7 +157,7 @@ export function get_input_files(cwd, include, exclude) {
 	const included = new Set();
 
 	for (const pattern of include) {
-		for (const file of globSync(pattern, { cwd })) {
+		for (const file of globSync(pattern, { cwd, ignore: exclude })) {
 			const resolved = path.resolve(cwd, file);
 			if (fs.statSync(resolved).isDirectory()) {
 				for (const file of globSync('**/*.{js,jsx,ts,tsx}', { cwd: resolved, ignore: exclude })) {


### PR DESCRIPTION
This change is useful if the included path has `node_modules` because currently it would keep globbing for a long while even if it has been excluded