### PR TITLE
fix: strip internal properties in .js files

### DIFF
--- a/.changeset/chatty-plums-divide.md
+++ b/.changeset/chatty-plums-divide.md
@@ -1,0 +1,5 @@
+---
+'dts-buddy': patch
+---
+
+fix: exclude class properties marked as `@internal` (.js files)

--- a/src/create-module-declaration.js
+++ b/src/create-module-declaration.js
@@ -8,6 +8,7 @@ import {
 	get_dts,
 	is_declaration,
 	is_internal,
+	is_property,
 	is_reference,
 	resolve_dts,
 	walk
@@ -367,7 +368,7 @@ export function create_module_declaration(id, entry, created, resolve, options) 
 				}
 
 				walk(node, (node) => {
-					if (ts.isPropertySignature(node) && is_internal(node) && options.stripInternal) {
+					if (options.stripInternal && is_internal(node) && is_property(node)) {
 						result.remove(node.pos, node.end);
 						return false;
 					}

--- a/src/utils.js
+++ b/src/utils.js
@@ -410,7 +410,7 @@ export function get_dts(file, created, resolve, options) {
 				current = previous;
 			} else {
 				walk(node, (node) => {
-					if (ts.isPropertySignature(node) && is_internal(node) && options.stripInternal) {
+					if (options.stripInternal && is_internal(node) && is_property(node)) {
 						return false;
 					}
 
@@ -596,6 +596,13 @@ export function is_reference(node, include_declarations = false) {
 	}
 
 	return true;
+}
+
+/** @param {ts.Node} node */
+export function is_property(node) {
+	if (ts.isPropertySignature(node)) return true;
+	if (ts.isPropertyDeclaration(node)) return true;
+	return false;
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -602,6 +602,8 @@ export function is_reference(node, include_declarations = false) {
 export function is_property(node) {
 	if (ts.isPropertySignature(node)) return true;
 	if (ts.isPropertyDeclaration(node)) return true;
+	if (ts.isGetAccessorDeclaration(node)) return true;
+	if (ts.isSetAccessorDeclaration(node)) return true;
 	return false;
 }
 

--- a/test/samples/strip-internal-js/input/index.js
+++ b/test/samples/strip-internal-js/input/index.js
@@ -23,4 +23,18 @@ export class Foo {
 
 		this.baz = baz;
 	}
+
+	/** @internal */
+	get _baz() {
+		return this._;
+	}
+
+	/**
+	 * @internal
+	 * @param {string | undefined} b
+	 */
+	set _baz(b) {
+		// @ts-ignore
+		this._ = b;
+	}
 }

--- a/test/samples/strip-internal-js/input/index.js
+++ b/test/samples/strip-internal-js/input/index.js
@@ -1,0 +1,26 @@
+export class Foo {
+	/** @type {number | undefined} */
+	foo;
+
+	bar = '';
+
+	/**
+	 * @internal
+	 * @type {number | undefined}
+	 */
+	_foo;
+
+	/**
+	 * @internal
+	 * @type {string | undefined}
+	 */
+	_bar;
+
+	/** @param {number} baz */
+	constructor(baz) {
+		/** @internal */
+		this._ = '';
+
+		this.baz = baz;
+	}
+}

--- a/test/samples/strip-internal-js/options.json
+++ b/test/samples/strip-internal-js/options.json
@@ -1,0 +1,3 @@
+{
+	"stripInternal": true
+}

--- a/test/samples/strip-internal-js/output/index.d.ts
+++ b/test/samples/strip-internal-js/output/index.d.ts
@@ -1,0 +1,14 @@
+declare module 'strip-internal-js' {
+	export class Foo {
+		
+		constructor(baz: number);
+		
+		foo: number | undefined;
+		bar: string;
+		baz: number;
+	}
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/strip-internal-js/output/index.d.ts.map
+++ b/test/samples/strip-internal-js/output/index.d.ts.map
@@ -1,0 +1,14 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"Foo"
+	],
+	"sources": [
+		"../input/index.js"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";cAAaA,GAAGA"
+}

--- a/test/samples/strip-internal/input/index.ts
+++ b/test/samples/strip-internal/input/index.ts
@@ -19,6 +19,18 @@ export class FooBar {
 	constructor() {
 		/** @internal */
 		// @ts-ignore
-		this._ = ''
+		this._ = '';
+	}
+
+	/** @internal */
+	get _baz() {
+		// @ts-ignore
+		return this._;
+	}
+
+	/** @internal * */
+	set _baz(b: string | undefined) {
+		// @ts-ignore
+		this._ = b;
 	}
 }

--- a/test/samples/strip-internal/input/index.ts
+++ b/test/samples/strip-internal/input/index.ts
@@ -4,3 +4,21 @@ export { Foo } from './others';
 export interface TSdddd {
 	foo: boolean;
 }
+
+export class FooBar {
+	foo: number | undefined;
+
+	/** @internal */
+	_foo: number | undefined;
+
+	bar = '';
+
+	/** @internal */
+	_bar: string | undefined;
+
+	constructor() {
+		/** @internal */
+		// @ts-ignore
+		this._ = ''
+	}
+}

--- a/test/samples/strip-internal/output/index.d.ts
+++ b/test/samples/strip-internal/output/index.d.ts
@@ -1,4 +1,9 @@
 declare module 'strip-internal' {
+	export class FooBar {
+		foo: number | undefined;
+		bar: string;
+		constructor();
+	}
 	export interface Foo {
 		bar: string;
 	}

--- a/test/samples/strip-internal/output/index.d.ts.map
+++ b/test/samples/strip-internal/output/index.d.ts.map
@@ -2,13 +2,16 @@
 	"version": 3,
 	"file": "index.d.ts",
 	"names": [
+		"FooBar",
 		"Foo"
 	],
 	"sources": [
+		"../input/index.ts",
 		"../input/others.d.ts"
 	],
 	"sourcesContent": [
+		null,
 		null
 	],
-	"mappings": ";kBAEiBA,GAAGA"
+	"mappings": ";cAOaA,MAAMA;;;;;kBCLFC,GAAGA"
 }


### PR DESCRIPTION
for some reason `@internal` wasn't working for me but the test was there... turns out .js properties are marked differently.

i've also moved the `options.stripInternal` check upfront, do let me know if that order was actually intentional