### PR TITLE
chore: fix prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"scripts": {
 		"changeset:version": "changeset version",
 		"changeset:publish": "changeset publish",
-		"prepublishOnly": "node src/cli.js --debug debug && tsc types/index.d.ts --esModuleInterop",
+		"prepublishOnly": "node src/cli.js",
 		"test": "node test/test.js",
 		"check": "tsc --noEmit --emitDeclarationOnly false",
 		"lint": "prettier --ignore-path .gitignore --ignore-path .prettierignore --cache --check .",


### PR DESCRIPTION
I believe this explains the recent failure to publish — the `prepublishOnly` script was erroring because `tsc` now fails if files are specified but there's also a `tsconfig.json`. I don't think we need to use `tsc` here at all (the file in question is generated by `src/cli.js`)