### PR TITLE
fix: avoid unnecessarily renaming types

### DIFF
--- a/.changeset/common-facts-flow.md
+++ b/.changeset/common-facts-flow.md
@@ -1,0 +1,5 @@
+---
+'dts-buddy': patch
+---
+
+fix: avoid renaming types matching generic or predicate names

--- a/src/utils.js
+++ b/src/utils.js
@@ -371,13 +371,6 @@ export function get_dts(file, created, resolve, options) {
 			}
 
 			const params = new Set();
-			if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
-				if (node.typeParameters) {
-					for (const param of node.typeParameters) {
-						params.add(param.name.getText(module.ast));
-					}
-				}
-			}
 
 			if (tsu.isNamespaceDeclaration(node)) {
 				const previous = current;
@@ -412,6 +405,10 @@ export function get_dts(file, created, resolve, options) {
 				walk(node, (node) => {
 					if (ts.isPropertySignature(node) && is_internal(node) && options.stripInternal) {
 						return false;
+					}
+
+					if (ts.isTypeParameterDeclaration(node)) {
+						params.add(node.name.getText(module.ast));
 					}
 
 					// `import('./foo').Foo` -> `Foo`
@@ -569,6 +566,8 @@ export function is_reference(node, include_declarations = false) {
 
 		if (ts.isImportTypeNode(node.parent)) return false;
 		if (ts.isPropertySignature(node.parent)) return false;
+		if (ts.isNamedTupleMember(node.parent)) return node !== node.parent.name;
+		if (ts.isTypePredicateNode(node.parent)) return node !== node.parent.parameterName;
 		if (ts.isGetAccessor(node.parent)) return false;
 		if (ts.isSetAccessor(node.parent)) return false;
 		if (ts.isParameter(node.parent)) return false;

--- a/test/samples/type-predicate/input/index.ts
+++ b/test/samples/type-predicate/input/index.ts
@@ -1,0 +1,9 @@
+export interface Thing {
+	value: string;
+}
+
+export function isThing(e: Thing | null): e is Thing {
+	return e !== null;
+}
+
+export { e } from './other';

--- a/test/samples/type-predicate/input/other.ts
+++ b/test/samples/type-predicate/input/other.ts
@@ -1,0 +1,3 @@
+export function e() {
+	return true;
+}

--- a/test/samples/type-predicate/output/index.d.ts
+++ b/test/samples/type-predicate/output/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'type-predicate' {
+	export interface Thing {
+		value: string;
+	}
+	export function isThing(e: Thing | null): e is Thing;
+	export function e(): boolean;
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/test/samples/type-predicate/output/index.d.ts.map
+++ b/test/samples/type-predicate/output/index.d.ts.map
@@ -1,0 +1,18 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"Thing",
+		"isThing",
+		"e"
+	],
+	"sources": [
+		"../input/index.ts",
+		"../input/other.ts"
+	],
+	"sourcesContent": [
+		null,
+		null
+	],
+	"mappings": ";kBAAiBA,KAAKA;;;iBAINC,OAAOA;iBCJPC,CAACA"
+}


### PR DESCRIPTION
This fixes a nasty issue where dts-buddy thinks the following are globals and renames any types matching them:
- generics such as `T`, `U`, etc.
- predicates such as `e` in `e is ...`
- parameter names such as `error` in `set example(error: any)`
- inferences such as `Id` in `example: infer Id`

Merging this fixes the issue where our `error` type doc gets deleted from `svelte.dev` because of the type bundling https://github.com/sveltejs/svelte.dev/pull/2042/changes#diff-a08187ba5fa6812ab9b17106a303af9a485e496430eeb73fea7f820c45dc1c27L76